### PR TITLE
Display missing loc key with prefix unless opt out

### DIFF
--- a/Runtime/LocalizedText.cs
+++ b/Runtime/LocalizedText.cs
@@ -11,6 +11,7 @@ namespace Padoru.Localization
 	public class LocalizedText : MonoBehaviour
 	{
 		[SerializeField] private string entryName;
+		[SerializeField] private bool useUnsafeLoc;
 
 		private Text text;
 		private TMP_Text tmpText;
@@ -47,7 +48,15 @@ namespace Padoru.Localization
 
 			try
 			{
-				localizedText = localizationManager.GetLocalizedText(entryName);
+				if (useUnsafeLoc)
+                {
+					localizedText = localizationManager.GetLocalizedText(entryName);
+				}
+				else
+                {
+					localizedText = entryName.ToLocalized();
+				}
+				
 			}
 			catch (Exception e)
 			{

--- a/Runtime/StringExtensions.cs
+++ b/Runtime/StringExtensions.cs
@@ -16,7 +16,7 @@ namespace Padoru.Localization
             }
 
             Debug.LogWarning("Missing localized text for key: " + key, Constants.LOCALIZATION_LOG_CHANNEL);
-            return $"Missing:{key}";
+            return $"MISSING:{key}";
         }
     }
 }

--- a/Runtime/StringExtensions.cs
+++ b/Runtime/StringExtensions.cs
@@ -16,7 +16,7 @@ namespace Padoru.Localization
             }
 
             Debug.LogWarning("Missing localized text for key: " + key, Constants.LOCALIZATION_LOG_CHANNEL);
-            return key;
+            return $"Missing:{key}";
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.padoru.localization-lib",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "displayName": "Padoru Localization",
   "description": "A library to handle language localization in Unity games",
   "unity": "2021.3",


### PR DESCRIPTION
Changes the behavior of `LocalizedText` component. Now it will use the `ToLocalized` extension method which is "safe", it checks if the string exist before attempting to read it form the loc. The component can opt in to use "unsafe" loc if it wants to. `ToLocalized` has changed to return the loc key with a fixed prefix of `missing:`

<img width="296" alt="image" src="https://github.com/PadoruGames/localization-lib/assets/167806650/84042a4e-6bae-4447-842b-d8982eacb089">

Future ideas:
* It would be nice if it were `missing:<loc_bundle>:<key>`. However currently our implementation of `LocalizationManager` has only private methods to access this, and `LocalizedText` would need access. I did not want to bloat this change with that refactor.
* It would be nice if `missing` were a setting we could update without changing source code. Maybe there is a baked in loc file shipped with the game (instead of downloaded) containing strings the app needs to function and we could including the "missing" string in there if people want to override it. Or, simplier, a stand along JSON config since we probably don't care to localize debug text.