### PR TITLE
RHO-3402 returned naked loc key without prefix

### DIFF
--- a/Runtime/StringExtensions.cs
+++ b/Runtime/StringExtensions.cs
@@ -16,7 +16,9 @@ namespace Padoru.Localization
             }
 
             Debug.LogWarning("Missing localized text for key: " + key, Constants.LOCALIZATION_LOG_CHANNEL);
-            return $"MISSING:{key}";
+            // Return the naked key for now https://series-ai.atlassian.net/browse/RHO-3402
+            //return $"MISSING:{key}";
+            return key;
         }
     }
 }


### PR DESCRIPTION
We do not have a loc entry for `Notifications`.

Before the change, we include the prefix:
<img width="240" alt="Screenshot 2024-05-02 at 7 13 22 PM" src="https://github.com/series-ai/localization-lib/assets/167806650/bb178606-1bc2-4f76-829b-e526f7707006">

After we do not:
<img width="239" alt="Screenshot 2024-05-02 at 7 12 31 PM" src="https://github.com/series-ai/localization-lib/assets/167806650/a29263b9-3833-4a48-baff-1931844e070f">
